### PR TITLE
[SDK-2690] Update composer.json's min-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,26 @@
     "optimize-autoloader": true,
     "sort-packages": true
   },
+  "minimum-stability": "beta",
+  "prefer-stable": true,
   "scripts": {
-    "app": "composer install --no-dev && php -S 127.0.0.1:3000 public/index.php",
-    "docker": "docker compose run install && docker compose run --rm --service-ports quickstart",
-    "tests": "docker compose run --rm tests"
+    "app": [
+      "@pre-run-app",
+      "composer install --no-dev",
+      "php -S 127.0.0.1:3000 public/index.php"
+    ],
+    "docker": [
+      "@pre-run-app",
+      "docker-compose run install",
+      "docker-compose run --rm --service-ports quickstart"
+    ],
+    "tests": [
+      "@pre-run-app",
+      "docker-compose run --rm tests"
+    ],
+    "pre-run-app": [
+      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+    ]
   },
   "license": "MIT"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,5 @@ services:
       - ./:/app
     working_dir: /app
     command: >
-      sh -c "rm ./composer.lock &&
+      sh -c "rm -f ./composer.lock &&
              composer install --no-dev"


### PR DESCRIPTION
This PR updates the QS to specify "minimum-stability" and "prefer-stable" options within the composer.json, to avoid warnings in certain environment configurations when attempting to install dependencies w/ beta tags.